### PR TITLE
Fixes issue mentioned in #164: remote endpoint address and port was n…

### DIFF
--- a/http_examples.cpp
+++ b/http_examples.cpp
@@ -89,7 +89,7 @@ int main() {
   // Responds with request-information
   server.resource["^/info$"]["GET"] = [](shared_ptr<HttpServer::Response> response, shared_ptr<HttpServer::Request> request) {
     stringstream stream;
-    stream << "<h1>Request from " << request->remote_endpoint_address << ":" << request->remote_endpoint_port << "</h1>";
+    stream << "<h1>Request from " << request->remote_endpoint_address() << ":" << request->remote_endpoint_port() << "</h1>";
 
     stream << request->method << " " << request->path << " HTTP/" << request->http_version;
 

--- a/https_examples.cpp
+++ b/https_examples.cpp
@@ -87,7 +87,7 @@ int main() {
   // Responds with request-information
   server.resource["^/info$"]["GET"] = [](shared_ptr<HttpsServer::Response> response, shared_ptr<HttpsServer::Request> request) {
     stringstream stream;
-    stream << "<h1>Request from " << request->remote_endpoint_address << ":" << request->remote_endpoint_port << "</h1>";
+    stream << "<h1>Request from " << request->remote_endpoint_address() << ":" << request->remote_endpoint_port() << "</h1>";
 
     stream << request->method << " " << request->path << " HTTP/" << request->http_version;
 

--- a/server_https.hpp
+++ b/server_https.hpp
@@ -48,15 +48,17 @@ namespace SimpleWeb {
     asio::ssl::context context;
 
     void accept() override {
-      auto session = std::make_shared<Session>(config.max_request_streambuf_size, create_connection(*io_service, context));
+      auto connection = create_connection(*io_service, context);
 
-      acceptor->async_accept(session->connection->socket->lowest_layer(), [this, session](const error_code &ec) {
-        auto lock = session->connection->handler_runner->continue_lock();
+      acceptor->async_accept(connection->socket->lowest_layer(), [this, connection](const error_code &ec) {
+        auto lock = connection->handler_runner->continue_lock();
         if(!lock)
           return;
 
         if(ec != asio::error::operation_aborted)
           this->accept();
+
+        auto session = std::make_shared<Session>(config.max_request_streambuf_size, connection);
 
         if(!ec) {
           asio::ip::tcp::no_delay option(true);

--- a/tests/parse_test.cpp
+++ b/tests/parse_test.cpp
@@ -152,7 +152,7 @@ int main() {
 
   asio::io_service io_service;
   asio::ip::tcp::socket socket(io_service);
-  SimpleWeb::Server<HTTP>::Request request(static_cast<size_t>(-1));
+  SimpleWeb::Server<HTTP>::Request request(static_cast<size_t>(-1), nullptr);
   {
     request.query_string = "";
     auto queries = request.parse_query_string();


### PR DESCRIPTION
…ot correctly set. Request::remote_endpoint_address and Request::remote_endpoint_port are now functions instead of variables in order to reduce unnecessary instructions.